### PR TITLE
chore(cloudflared): Update to version 2020.5.0

### DIFF
--- a/cloudflared.rb
+++ b/cloudflared.rb
@@ -1,9 +1,9 @@
 class Cloudflared < Formula
   desc 'Argo Tunnel'
   homepage 'https://developers.cloudflare.com/argo-tunnel/'
-  url 'https://developers.cloudflare.com/argo-tunnel/dl/cloudflared-2020.2.0-darwin-amd64.tgz'
-  sha256 '9eb18f3d5b5e926dcbafecd35957c0709efbc10bf21d3e2523ab0392f0095643'
-  version '2020.2.0'
+  url 'https://bin.equinox.io/a/aZkwrDbBrND/cloudflared-2020.5.0-darwin-amd64.tar.gz'
+  sha256 'b06ec742c1a18bd5a6ac31b7279f68a8dc787189a8e1b5f2aecee3b376725c85'
+  version '2020.5.0'
   def install
     bin.install 'cloudflared'
   end


### PR DESCRIPTION
```
$ wget https://bin.equinox.io/a/aZkwrDbBrND/cloudflared-2020.5.0-darwin-amd64.tar.gz
HTTP request sent, awaiting response... 200 OK
Length: 18369288 (18M) [application/octet-stream]
Saving to: ‘cloudflared-2020.5.0-darwin-amd64.tar.gz’
```

```
$ shasum -a 256 cloudflared-2020.5.0-darwin-amd64.tar.gz
b06ec742c1a18bd5a6ac31b7279f68a8dc787189a8e1b5f2aecee3b376725c85  cloudflared-2020.5.0-darwin-amd64.tar.gz
```