### PR TITLE
Update curl formula

### DIFF
--- a/curl.rb
+++ b/curl.rb
@@ -47,7 +47,7 @@ class Curl < Formula
 
       system "cargo", "build",
                       "--release",
-                      "--features", "pkg-config-meta,qlog"
+                      "--features", "pkg-config-meta,qlog,ffi"
 
       mkdir_p "deps/boringssl/src/lib"
       cp Dir.glob("target/release/build/*/out/build/libcrypto.a"), "deps/boringssl/src/lib"


### PR DESCRIPTION
FFI was made an optional feature in quiche at commit https://github.com/cloudflare/quiche/commit/35e38d987c1e53ef2bd5f23b754c50162b5adac8, and because of this the formula did not build. Enabling the ffi feature allows the formula to build. This commit closes issue #21.