### PR TITLE
cf-terraforming: add formula

### DIFF
--- a/cf-terraforming.rb
+++ b/cf-terraforming.rb
@@ -1,0 +1,24 @@
+class CfTerraforming < Formula
+  desc "cf-terraforming is a command line utility to facilitate terraforming your existing Cloudflare resources"
+  homepage "https://github.com/cloudflare/cf-terraforming"
+  url "https://github.com/cloudflare/cf-terraforming/archive/refs/tags/v0.1.0.tar.gz"
+  license "MPL-2.0"
+
+  depends_on "go" => :build
+  bottle :unneeded
+
+  def install
+    ENV["GOPATH"] = buildpath
+
+    bin_path = buildpath/"src/github.com/cloudflare/cf-terraforming"
+    bin_path.install Dir["*"]
+    cd bin_path do
+      system "make", "build"
+      bin.install "cf-terraforming"
+    end
+  end
+
+  test do
+    system "which", "cf-terraforming"
+  end
+end


### PR DESCRIPTION
With the recent changes in `cf-terraforming`, we want to make it easier for people to get up and running faster. One of the improvements is adding a Homebrew formula for Mac users who can run `brew install cf-terraforming` instead of manually cloning and building.

v0.1.0 doesn't exist at the moment however it will at some point next week once we cut the release and I'll add a sha to the formula. 