### PR TITLE
Bumping v0.6.3 and respective SHA256 Checksums

### DIFF
--- a/Casks/cf-terraforming.rb
+++ b/Casks/cf-terraforming.rb
@@ -3,14 +3,14 @@ cask "cf-terraforming" do
   appcast "https://github.com/cloudflare/cf-terraforming/releases.atom"
   homepage "https://github.com/cloudflare/cf-terraforming"
   desc "cf-terraforming is a command line utility to facilitate terraforming your existing Cloudflare resources"
-  version "0.6.0"
+  version "0.6.3"
 
   if Hardware::CPU.intel?
     url "https://github.com/cloudflare/cf-terraforming/releases/download/v#{version}/cf-terraforming_#{version}_darwin_amd64.tar.gz"
-    sha256 "cad76567c1f0ba0266d950dbff3b42bbf423025eb73f967c7092e2ab71bc69be"
+    sha256 "dacbcd8563e2c83f3e9069bba9ff450f4486b759af9a7d7562a806c7dea6c853"
   else
     url "https://github.com/cloudflare/cf-terraforming/releases/download/v#{version}/cf-terraforming_#{version}_darwin_arm64.tar.gz"
-    sha256 "741e617a3adb57d3d80f0b0f68c0a56c6afd2ddd7b58b0309d56befee18b66f3"
+    sha256 "b45406cd187b4e848fe050ede767e3705c4ddd4d8f5c051a727fd81eccdfc30a"
   end
 
   binary "cf-terraforming"


### PR DESCRIPTION
Updated version to new release 0.6.3 and updating accompanying checksums for Intel and ARM platforms.

v0.6.3 checksums can be found here: https://github.com/cloudflare/cf-terraforming/releases/download/v0.6.3/checksums.txt