### PR TITLE
Update curl.rb for building with latest quiche

### DIFF
--- a/curl.rb
+++ b/curl.rb
@@ -44,15 +44,16 @@ class Curl < Formula
     # build quiche
     cd "quiche" do
       # Build static libs only
-      inreplace "Cargo.toml", /^crate-type = .*/, "crate-type = [\"staticlib\"]"
+      inreplace "quiche/Cargo.toml", /^crate-type = .*/, "crate-type = [\"staticlib\"]"
 
       system "cargo", "build",
+                      "--package quiche",
                       "--release",
-                      "--features", "ffi,pkg-config-meta,qlog"
+                      "--features=ffi,pkg-config-meta,qlog"
 
-      mkdir_p "deps/boringssl/src/lib"
-      cp Dir.glob("target/release/build/*/out/build/libcrypto.a"), "deps/boringssl/src/lib"
-      cp Dir.glob("target/release/build/*/out/build/libssl.a"), "deps/boringssl/src/lib"
+      mkdir_p "quiche/deps/boringssl/src/lib"
+      cp Dir.glob("target/release/build/*/out/build/libcrypto.a"), "quiche/deps/boringssl/src/lib"
+      cp Dir.glob("target/release/build/*/out/build/libssl.a"), "quiche/deps/boringssl/src/lib"
     end
 
     args = %W[
@@ -63,7 +64,7 @@ class Curl < Formula
       --with-secure-transport
       --without-ca-bundle
       --without-ca-path
-      --with-ssl=#{pwd}/quiche/deps/boringssl/src
+      --with-ssl=#{pwd}/quiche/quiche/deps/boringssl/src
       --with-quiche=#{pwd}/quiche/target/release
       --enable-alt-svc
     ]

--- a/curl.rb
+++ b/curl.rb
@@ -1,17 +1,27 @@
 #
 # Homebrew Formula for curl + quiche
+# Based on https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/curl.rb
 #
 # brew install -s <url of curl.rb>
 #
 # You can add --HEAD if you want to build curl from git master (recommended)
 #
-# For more information, see https://developers.cloudflare.com/http3/curl-brew
+# For more information, see https://developers.cloudflare.com/http3/tutorials/curl-brew
 #
 class Curl < Formula
-  desc "Get a file from an HTTP, HTTPS or FTP server with HTTP/3 using quiche"
-  homepage "https://curl.haxx.se/"
-  url "https://curl.haxx.se/download/curl-7.71.1.tar.bz2"
-  sha256 "9d52a4d80554f9b0d460ea2be5d7be99897a1a9f681ffafe739169afd6b4f224"
+  desc "Get a file from an HTTP, HTTPS or FTP server with HTTP/3 support using quiche"
+  homepage "https://curl.se"
+  url "https://curl.se/download/curl-7.81.0.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-7_80_0/curl-7.81.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/curl-7.81.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/legacy/curl-7.81.0.tar.bz2"
+  sha256 "1e7a38d7018ec060f1f16df839854f0889e94e122c4cfa5d3a37c2dc56f1e258"
+  license "curl"
+
+  livecheck do
+    url "https://curl.se/download/"
+    regex(/href=.*?curl[._-]v?(.*?)\.t/i)
+  end
 
   head do
     url "https://github.com/curl/curl.git"
@@ -23,32 +33,32 @@ class Curl < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "pkg-config" => :build
-  uses_from_macos "openssl"
-
-  depends_on "rust" => ["1.50.0", :build]
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "brotli"
+  depends_on "libidn2"
+  depends_on "libnghttp2"
+  depends_on "libssh2"
+  depends_on "openldap"
+  depends_on "openssl@1.1"
+  depends_on "rtmpdump"
+  depends_on "zstd"
 
-  # http2
-  depends_on "nghttp2" => :build
+  uses_from_macos "krb5"
+  uses_from_macos "zlib"
 
   def install
-    # Instructions from https://github.com/curl/curl/blob/master/docs/HTTP3.md
-    pwd = Pathname.pwd
-
-    system "autoreconf", "-fi" if build.head?
-
-    # build boringssl
+    # Build with quiche:
+    #   https://github.com/curl/curl/blob/master/docs/HTTP3.md#quiche-version
     system "git", "clone", "--recursive", "https://github.com/cloudflare/quiche"
-
-    # build quiche
     cd "quiche" do
       # Build static libs only
       inreplace "quiche/Cargo.toml", /^crate-type = .*/, "crate-type = [\"staticlib\"]"
 
       system "cargo", "build",
-                      "--package quiche",
                       "--release",
+                      "--package=quiche",
                       "--features=ffi,pkg-config-meta,qlog"
 
       mkdir_p "quiche/deps/boringssl/src/lib"
@@ -56,18 +66,30 @@ class Curl < Formula
       cp Dir.glob("target/release/build/*/out/build/libssl.a"), "quiche/deps/boringssl/src/lib"
     end
 
+    system "./buildconf" if build.head?
+
     args = %W[
       --disable-debug
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
+      --with-ssl=#{Pathname.pwd}/quiche/quiche/deps/boringssl/src
+      --with-ca-fallback
       --with-secure-transport
-      --without-ca-bundle
-      --without-ca-path
-      --with-ssl=#{pwd}/quiche/quiche/deps/boringssl/src
-      --with-quiche=#{pwd}/quiche/target/release
+      --with-default-ssl-backend=openssl
+      --with-libidn2
+      --with-librtmp
+      --with-libssh2
+      --without-libpsl
+      --with-quiche=#{Pathname.pwd}/quiche/target/release
       --enable-alt-svc
     ]
+
+    args << if OS.mac?
+      "--with-gssapi"
+    else
+      "--with-gssapi=#{Formula["krb5"].opt_prefix}"
+    end
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
* build with latest quiche build structure changes, based on #41 
* re-sync with latest homebrew curl formula (7.81.0)