### PR TITLE
Fix reference to `mk-ca-bundle.pl`

### DIFF
--- a/curl.rb
+++ b/curl.rb
@@ -96,7 +96,7 @@ class Curl < Formula
     system "./configure", *args
     system "make", "install"
     system "make", "install", "-C", "scripts"
-    libexec.install "lib/mk-ca-bundle.pl"
+    libexec.install "scripts/mk-ca-bundle.pl"
   end
 
   test do


### PR DESCRIPTION
Hi team, thanks for making this script! It's super helpful for playing around with http3 🙂.

In curl/curl#8625, `mk-ca-bundle.pl` was moved from `lib/` to `scripts/`. The installer today fails with the following error:
```
==> make install -C scripts
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - lib/mk-ca-bundle.pl
```

This PR fixes the path to `mk-ca-bundle.pl` so the build works with the latest checkout of `curl`.