### PR TITLE
curl.rb: Fix a build with latest curl

### DIFF
--- a/curl.rb
+++ b/curl.rb
@@ -11,11 +11,11 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server with HTTP/3 support using quiche"
   homepage "https://curl.se"
-  url "https://curl.se/download/curl-7.81.0.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-7_80_0/curl-7.81.0.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/curl-7.81.0.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/legacy/curl-7.81.0.tar.bz2"
-  sha256 "1e7a38d7018ec060f1f16df839854f0889e94e122c4cfa5d3a37c2dc56f1e258"
+  url "https://curl.se/download/curl-8.2.0.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-8_2_0/curl-8.2.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/curl-8.2.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/legacy/curl-8.2.0.tar.bz2"
+  sha256 "080aaa5bef29ab3f592101e7a95f32ddbe88b92125cb28dde479d5a104928ea4"
   license "curl"
 
   livecheck do
@@ -41,7 +41,6 @@ class Curl < Formula
   depends_on "libnghttp2"
   depends_on "libssh2"
   depends_on "openldap"
-  depends_on "openssl@1.1"
   depends_on "rtmpdump"
   depends_on "zstd"
 
@@ -76,6 +75,8 @@ class Curl < Formula
       --disable-silent-rules
       --prefix=#{prefix}
       --with-ssl=#{quiche}/deps/boringssl/src
+      --without-ca-bundle
+      --without-ca-path
       --with-ca-fallback
       --with-secure-transport
       --with-default-ssl-backend=openssl
@@ -96,7 +97,7 @@ class Curl < Formula
     system "./configure", *args
     system "make", "install"
     system "make", "install", "-C", "scripts"
-    libexec.install "lib/mk-ca-bundle.pl"
+    libexec.install "scripts/mk-ca-bundle.pl"
   end
 
   test do


### PR DESCRIPTION
Fix a build failure due to a recent change in curl. Also upgrade curl to 8.2.0

Tested using HEAD and the release (8.2.0). (macOS ventura + m1 macBook Pro)

Fixes #45, fixes #46, fixes #51.