### PR TITLE
Update remote version check to use `livecheck`

### DIFF
--- a/Casks/cf-terraforming.rb
+++ b/Casks/cf-terraforming.rb
@@ -7,7 +7,9 @@ cask "cf-terraforming" do
          intel: "910965fcf822242e96048744f128324b620518daf0aa75bfe76710e06c646ad9"
 
   url "https://github.com/cloudflare/cf-terraforming/releases/download/v#{version}/cf-terraforming_#{version}_darwin_#{arch}.tar.gz"
-  appcast "https://github.com/cloudflare/cf-terraforming/releases.atom"
+  livecheck do
+    url "https://github.com/cloudflare/cf-terraforming/releases.atom"
+  end
   name "cf-terraforming"
   desc "Utility to export your existing Cloudflare resources as Terraform resources"
   homepage "https://github.com/cloudflare/cf-terraforming"


### PR DESCRIPTION
💁 This change updates the mechanism used for remote version checks to use `livecheck` instead of `appcast`. Without it I had the following error returned from `brew upgrade --cask --greedy`:

    Error: Cask 'cf-terraforming' definition is invalid: 'appcast' stanza
    failed with: Calling the `appcast` stanza is deprecated! Use the
    `livecheck` stanza instead.

https://docs.brew.sh/Brew-Livecheck