### PR TITLE
TUN-8140: Deprecate cloudflared and disable warp from cloudflare-homebrew

### DIFF
--- a/cloudflared.rb
+++ b/cloudflared.rb
@@ -1,4 +1,5 @@
 class Cloudflared < Formula
+  deprecate! date: "2024-01-10", because: "moved to homebrew-core repository"
   desc 'Cloudflare Tunnel'
   homepage 'https://developers.cloudflare.com/cloudflare-one/connections/connect-apps'
   url 'https://packages.argotunnel.com/dl/cloudflared-2024.1.1-darwin-amd64.tgz'

--- a/warp.rb
+++ b/warp.rb
@@ -1,4 +1,5 @@
 class Warp < Formula
+  disable! date: "2024-01-10", because: :unmaintained
   desc 'Cloudflare Warp'
   homepage 'https://warp.cloudflare.com'
   url 'https://warp.cloudflare.com/dl/warp-2018.3.0-darwin-amd64.tgz'


### PR DESCRIPTION
## Summary
The tunnel team decided that the homebrew-core will be the official repository
for cloudflared and therefore, the artifact on this repository will be deprecated
and afterwards disabled.

Closes #74 
Closes #30
Closes #14 
Closes #13 
Closes #9