### PR TITLE
replace plist with modern service definition

### DIFF
--- a/nginx.rb
+++ b/nginx.rb
@@ -152,30 +152,10 @@ class Nginx< Formula
     EOS
   end
 
-  plist_options :manual => "nginx"
-
-  def plist; <<~EOS
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <false/>
-        <key>ProgramArguments</key>
-        <array>
-            <string>#{opt_bin}/nginx</string>
-            <string>-g</string>
-            <string>daemon off;</string>
-        </array>
-        <key>WorkingDirectory</key>
-        <string>#{HOMEBREW_PREFIX}</string>
-      </dict>
-    </plist>
-  EOS
+  service do
+    run [opt_bin/"nginx", "-g", "daemon off;"]
+    keep_alive false
+    working_dir HOMEBREW_PREFIX
   end
 
   test do


### PR DESCRIPTION
Homebrew has deprecated `plist_options`, you will get the following error when tapping this repo.

```
Error: Invalid formula (sonoma): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (arm64_sonoma): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (ventura): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (arm64_ventura): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (monterey): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (arm64_monterey): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (big_sur): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (arm64_big_sur): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (catalina): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (mojave): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (high_sierra): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (sierra): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (el_capitan): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Invalid formula (x86_64_linux): /opt/homebrew/Library/Taps/cloudflare/homebrew-cloudflare/nginx.rb
nginx: undefined method `plist_options' for Formulary::ReadallNamespace::Nginx:Class
Error: Cannot tap cloudflare/cloudflare: invalid syntax in tap!
```